### PR TITLE
[WF-40, WF-41] Add rock and goss tests for temporal admin tools

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -42,6 +42,10 @@ Furthermore, we have `just` commands to be able to pack from the project root. F
 just pack temporal-server/1.23.1
 ```
 
+## Versioning of artifacts in the rocks
+
+Each of the rocks hosted in this repository build temporal artifacts or other necessary tools. More than one of these rocks can be packed with the same artifact, e.g. both the temporal-server and temporal-admin-tools rocks have the temporal cli. It is necessary to ensure that when we bump the version of temporal cli in one of these rocks, we consider whether the version should be bumped in the other rocks that contain it too.
+
 ## Running a built Temporal rock
 
 To run the built rock in a K8s distribution, please ensure that `kubectl` has the proper configuration to interact with the K8s distribution.

--- a/justfile
+++ b/justfile
@@ -23,7 +23,7 @@ push-to-local-registry component version:
 
 	rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
 		"oci-archive:${component}/${version}/${rock_file}" \
-		"docker://localhost:5000/temporal-server-dev:${version}"
+		"docker://localhost:5000/${component}-dev:${version}"
 
 [private]
 format_directory directory:

--- a/temporal-admin-tools/1.23.1/rockcraft.yaml
+++ b/temporal-admin-tools/1.23.1/rockcraft.yaml
@@ -13,7 +13,7 @@ platforms: # the platforms this rock should be built on and run on
 parts:
     temporal-cli:
         plugin: go
-        source: https://github.com/temporalio/cli.git
+        source: https://github.com/temporalio/cli
         source-type: git
         source-tag: v1.3.0
         build-snaps:
@@ -59,7 +59,7 @@ parts:
             - etc/temporal/schema
     temporal-cli-license:
         plugin: dump
-        source: https://github.com/temporalio/cli.git
+        source: https://github.com/temporalio/cli
         source-type: git
         source-tag: v1.3.0
         organize:

--- a/temporal-admin-tools/1.23.1/rockcraft.yaml
+++ b/temporal-admin-tools/1.23.1/rockcraft.yaml
@@ -5,7 +5,7 @@ base: ubuntu@24.04 # the base environment for this rock
 version: '1.23.1' # just for humans. Semantic versioning is recommended
 summary: Rock for Temporal Admin Tools # 79 char long summary
 description: |
-    Temporal is a durable execution platform that enables developers to build scalable applications without sacrificing productivity or reliability. This image contains necessary tools to configure and administer a Temporal deployment.
+    This image contains necessary tools to configure and administer a Temporal server.
 
 platforms: # the platforms this rock should be built on and run on
     amd64:

--- a/temporal-admin-tools/1.23.1/rockcraft.yaml
+++ b/temporal-admin-tools/1.23.1/rockcraft.yaml
@@ -1,0 +1,68 @@
+name: temporal-admin-tools
+# see https://documentation.ubuntu.com/rockcraft/en/1.12.0/explanation/bases/
+# for more information about bases and using 'bare' bases for chiselled rocks
+base: ubuntu@24.04 # the base environment for this rock
+version: '1.23.1' # just for humans. Semantic versioning is recommended
+summary: Rock for Temporal Admin Tools # 79 char long summary
+description: |
+    Temporal is a durable execution platform that enables developers to build scalable applications without sacrificing productivity or reliability. This image contains necessary tools to configure and administer a Temporal deployment.
+
+platforms: # the platforms this rock should be built on and run on
+    amd64:
+
+parts:
+    temporal-cli:
+        plugin: go
+        source: https://github.com/temporalio/cli.git
+        source-type: git
+        source-tag: v1.3.0
+        build-snaps:
+            - go/1.24/stable
+        override-build: |
+            go build -ldflags "-X 'github.com/temporalio/cli/temporalcli.Version=v1.3.0'" -o ${CRAFT_PART_INSTALL}/bin/temporal ./cmd/temporal
+    temporal-sql-tool:
+        plugin: go
+        source: https://github.com/temporalio/temporal
+        source-subdir: cmd/tools/sql
+        source-type: git
+        source-tag: v1.23.1
+        build-snaps:
+            - go/1.21/stable
+        organize:
+            bin/sql: bin/temporal-sql-tool
+    tdbg:
+        plugin: go
+        source: https://github.com/temporalio/temporal
+        source-subdir: cmd/tools/tdbg
+        source-type: git
+        source-tag: v1.23.1
+        build-snaps:
+            - go/1.21/stable
+    temporal-admin-tools-rock-license:
+        plugin: dump
+        source: https://github.com/canonical/temporal-rocks.git
+        source-type: git
+        organize:
+            LICENSE: licenses/LICENSE-temporal-admin-tools-rock
+        stage:
+            - licenses/LICENSE-temporal-admin-tools-rock
+    temporal-license-and-schema:
+        plugin: dump
+        source: https://github.com/temporalio/temporal
+        source-type: git
+        source-tag: v1.23.1
+        organize:
+            schema: etc/temporal/schema
+            LICENSE: licenses/LICENSE-temporal
+        stage:
+            - licenses/LICENSE-temporal
+            - etc/temporal/schema
+    temporal-cli-license:
+        plugin: dump
+        source: https://github.com/temporalio/cli.git
+        source-type: git
+        source-tag: v1.3.0
+        organize:
+            LICENSE: licenses/LICENSE-temporal-cli
+        stage:
+            - licenses/LICENSE-temporal-cli

--- a/temporal-admin-tools/1.23.1/rockcraft.yaml
+++ b/temporal-admin-tools/1.23.1/rockcraft.yaml
@@ -19,7 +19,7 @@ parts:
         build-snaps:
             - go/1.24/stable
         override-build: |
-            go build -ldflags "-X 'github.com/temporalio/cli/temporalcli.Version=v1.3.0'" -o ${CRAFT_PART_INSTALL}/bin/temporal ./cmd/temporal
+            go build -ldflags "-X 'github.com/temporalio/cli/temporalcli.Version=1.3.0'" -o ${CRAFT_PART_INSTALL}/bin/temporal ./cmd/temporal
     temporal-sql-tool:
         plugin: go
         source: https://github.com/temporalio/temporal

--- a/temporal-admin-tools/goss.yaml
+++ b/temporal-admin-tools/goss.yaml
@@ -1,0 +1,78 @@
+file:
+  /usr/bin/temporal:
+    exists: true
+    path: /usr/bin/temporal
+    mode: '0755'
+    owner: root
+    group: root
+    filetype: file
+  /usr/bin/temporal-sql-tool:
+    exists: true
+    path: /usr/bin/temporal-sql-tool
+    mode: '0755'
+    owner: root
+    group: root
+    filetype: file
+  /usr/bin/tdbg:
+    exists: true
+    path: /usr/bin/tdbg
+    mode: '0755'
+    owner: root
+    group: root
+    filetype: file
+  /licenses/LICENSE-temporal-admin-tools-rock:
+    exists: true
+    path: /licenses/LICENSE-temporal-admin-tools-rock
+    mode: '0644'
+    owner: root
+    group: root
+    filetype: file
+  /licenses/LICENSE-temporal:
+    exists: true
+    path: /licenses/LICENSE-temporal
+    mode: '0644'
+    owner: root
+    group: root
+    filetype: file
+  /licenses/LICENSE-temporal-cli:
+    exists: true
+    path: /licenses/LICENSE-temporal-cli
+    mode: '0644'
+    owner: root
+    group: root
+    filetype: file
+  /etc/temporal/schema/postgresql:
+    exists: true
+    path: /etc/temporal/schema/postgresql
+    mode: '0755'
+    owner: root
+    group: root
+    filetype: directory
+process:
+  pebble:
+    running: true
+command:
+  'temporal --version':
+    exit-status: 0
+    exec: 'temporal --version'
+    stdout:
+    - temporal version v1.3.0 (Server 1.27.1, UI 2.36.0)
+    stderr: []
+    timeout: 1000
+    skip: false
+  'temporal-sql-tool --version':
+    exit-status: 0
+    exec: 'temporal-sql-tool --version'
+    stdout:
+    - temporal-sql-tool version 0.0.1
+    stderr: []
+    timeout: 1000
+    skip: false
+  'tdbg --version':
+    exit-status: 0
+    exec: 'tdbg --version'
+    stdout:
+    - tdbg version 1.23.1
+    stderr: []
+    timeout: 1000
+    skip: false

--- a/temporal-admin-tools/goss.yaml
+++ b/temporal-admin-tools/goss.yaml
@@ -52,11 +52,21 @@ process:
   pebble:
     running: true
 command:
+  'temporal server start-dev':
+    exit-status: 124
+    exec: 'timeout 5 temporal server start-dev'
+    stdout:
+    - CLI 1.3.0 (Server 1.27.1, UI 2.36.0)
+    - 'Server:  localhost:7233'
+    - 'UI:      http://localhost:8233'
+    - "Stopping server..."
+    stderr: []
+    skip: false
   'temporal --version':
     exit-status: 0
     exec: 'temporal --version'
     stdout:
-    - temporal version v1.3.0 (Server 1.27.1, UI 2.36.0)
+    - temporal version 1.3.0 (Server 1.27.1, UI 2.36.0)
     stderr: []
     timeout: 1000
     skip: false

--- a/temporal-admin-tools/goss_wait.yaml
+++ b/temporal-admin-tools/goss_wait.yaml
@@ -1,0 +1,3 @@
+process:
+  pebble:
+    running: true

--- a/temporal-admin-tools/justfile
+++ b/temporal-admin-tools/justfile
@@ -50,6 +50,6 @@ test version: (start-local-registry) (pack version) (push-to-local-registry vers
 	rock_version="${rock_version#temporal-admin-tools/}"
 
 	extra_options+="-e TEMPORAL_ROOT=/etc/temporal -e TEMPORAL_ENVIRONMENT=development-sqlite"
-	goss_vars="GOSS_KUBECTL_BIN=\"$(which kubectl)\" GOSS_OPTS=\"--retry-timeout 60s\""
+	goss_vars="GOSS_KUBECTL_BIN=\"$(which kubectl)\" GOSS_OPTS=\"--retry-timeout 60s --sleep 10s\""
 
 	eval "env ${goss_vars} kgoss run -i localhost:5000/temporal-admin-tools-dev:${rock_version} ${extra_options}"

--- a/temporal-admin-tools/justfile
+++ b/temporal-admin-tools/justfile
@@ -1,0 +1,66 @@
+set quiet # Recipes are silent by default
+set export # Just variables are exported to environment variables
+
+[private]
+default:
+	just --list
+
+[private]
+start-local-registry: (stop-local-registry)
+	docker run -d -p 5000:5000 --name registry registry:2.7
+
+[private]
+stop-local-registry: 
+	docker stop registry || true
+	docker rm registry || true
+
+[private]
+push-to-local-registry version:
+	#!/usr/bin/bash
+	set -euox pipefail
+
+	rock_file=$(ls "${version}" | grep "\.rock")
+	version="${version#temporal-server/}"
+
+	rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
+		"oci-archive:${version}/${rock_file}" \
+		"docker://localhost:5000/temporal-admin-tools-dev:${version}"
+
+# Clean the rockcraft project of the component and remove any existing rock files
+clean version:
+	cd "${version#temporal-admin-tools/}" && rockcraft clean
+	cd "${version#temporal-admin-tools/}" && rm -f "$(ls | grep *.rock)"
+
+# Pack a rock for a specific component
+pack version debug="":
+	#!/usr/bin/bash
+	debug_options=$(if [ -n "${debug}" ]; then echo "--debug"; fi)
+	cd "${version}" && rockcraft pack ${debug_options}
+
+# Pack rock for component and run pod with rock in kubernetes
+run version: (start-local-registry) (pack version) (push-to-local-registry version)
+	#!/usr/bin/bash
+	set -euxo pipefail
+
+	trap 'just stop-local-registry' EXIT
+
+	version="${version#temporal-admin-tools/}"
+
+	extra_options="-e TEMPORAL_ROOT=/etc/temporal -e TEMPORAL_ENVIRONMENT=development-sqlite"
+	goss_vars="GOSS_KUBECTL_BIN=\"$(which kubectl)\" GOSS_OPTS=\"--retry-timeout 60s --color\""
+	
+	eval "env ${goss_vars} kgoss edit -i localhost:5000/temporal-admin-tools-dev:${version} ${extra_options}"
+
+# Pack rock for component and run goss tests with rock in kubernetes
+test version: (start-local-registry) (pack version) (push-to-local-registry version)
+	#!/usr/bin/bash
+	set -euxo pipefail
+
+	trap 'just stop-local-registry' EXIT
+
+	version="${version#temporal-admin-tools/}"
+
+	extra_options+="-e TEMPORAL_ROOT=/etc/temporal -e TEMPORAL_ENVIRONMENT=development-sqlite"
+	goss_vars="GOSS_KUBECTL_BIN=\"$(which kubectl)\" GOSS_OPTS=\"--retry-timeout 60s\""
+
+	eval "env ${goss_vars} kgoss run -i localhost:5000/temporal-admin-tools-dev:${version} ${extra_options}"

--- a/temporal-admin-tools/justfile
+++ b/temporal-admin-tools/justfile
@@ -1,41 +1,26 @@
-set quiet # Recipes are silent by default
 set export # Just variables are exported to environment variables
+set fallback # Traverse upward in directory structure to find shared targets
 
 [private]
 default:
 	just --list
 
 [private]
-start-local-registry: (stop-local-registry)
-	docker run -d -p 5000:5000 --name registry registry:2.7
-
-[private]
-stop-local-registry: 
-	docker stop registry || true
-	docker rm registry || true
+start-local-registry:
+	just --justfile=../justfile start-local-registry
 
 [private]
 push-to-local-registry version:
-	#!/usr/bin/bash
-	set -euox pipefail
-
-	rock_file=$(ls "${version}" | grep "\.rock")
-	version="${version#temporal-server/}"
-
-	rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
-		"oci-archive:${version}/${rock_file}" \
-		"docker://localhost:5000/temporal-admin-tools-dev:${version}"
+	just --justfile=../justfile push-to-local-registry "temporal-admin-tools" $version
 
 # Clean the rockcraft project of the component and remove any existing rock files
 clean version:
 	cd "${version#temporal-admin-tools/}" && rockcraft clean
 	cd "${version#temporal-admin-tools/}" && rm -f "$(ls | grep *.rock)"
 
-# Pack a rock for a specific component
+# Pack a rock for the provided version
 pack version debug="":
-	#!/usr/bin/bash
-	debug_options=$(if [ -n "${debug}" ]; then echo "--debug"; fi)
-	cd "${version}" && rockcraft pack ${debug_options}
+	just --justfile=../justfile pack temporal-admin-tools/${version} ${debug}
 
 # Pack rock for component and run pod with rock in kubernetes
 run version: (start-local-registry) (pack version) (push-to-local-registry version)

--- a/temporal-admin-tools/justfile
+++ b/temporal-admin-tools/justfile
@@ -29,12 +29,14 @@ run version: (start-local-registry) (pack version) (push-to-local-registry versi
 
 	trap 'just stop-local-registry' EXIT
 
-	version="${version#temporal-admin-tools/}"
+	rock_version="$(just format_directory $version)"
+
+	rock_version="${rock_version#temporal-admin-tools/}"
 
 	extra_options="-e TEMPORAL_ROOT=/etc/temporal -e TEMPORAL_ENVIRONMENT=development-sqlite"
 	goss_vars="GOSS_KUBECTL_BIN=\"$(which kubectl)\" GOSS_OPTS=\"--retry-timeout 60s --color\""
 	
-	eval "env ${goss_vars} kgoss edit -i localhost:5000/temporal-admin-tools-dev:${version} ${extra_options}"
+	eval "env ${goss_vars} kgoss edit -i localhost:5000/temporal-admin-tools-dev:${rock_version} ${extra_options}"
 
 # Pack rock for component and run goss tests with rock in kubernetes
 test version: (start-local-registry) (pack version) (push-to-local-registry version)
@@ -43,9 +45,11 @@ test version: (start-local-registry) (pack version) (push-to-local-registry vers
 
 	trap 'just stop-local-registry' EXIT
 
-	version="${version#temporal-admin-tools/}"
+	rock_version="$(just format_directory $version)"
+
+	rock_version="${rock_version#temporal-admin-tools/}"
 
 	extra_options+="-e TEMPORAL_ROOT=/etc/temporal -e TEMPORAL_ENVIRONMENT=development-sqlite"
 	goss_vars="GOSS_KUBECTL_BIN=\"$(which kubectl)\" GOSS_OPTS=\"--retry-timeout 60s\""
 
-	eval "env ${goss_vars} kgoss run -i localhost:5000/temporal-admin-tools-dev:${version} ${extra_options}"
+	eval "env ${goss_vars} kgoss run -i localhost:5000/temporal-admin-tools-dev:${rock_version} ${extra_options}"

--- a/temporal-server/1.23.1/rockcraft.yaml
+++ b/temporal-server/1.23.1/rockcraft.yaml
@@ -39,14 +39,14 @@ parts:
             bin/server: bin/temporal-server
     temporal-cli:
         plugin: go
-        source: https://github.com/temporalio/cli.git
+        source: https://github.com/temporalio/cli
         source-type: git
         source-tag: v1.3.0
         build-snaps:
             - go/1.24/stable
     temporal-server-rock-license:
         plugin: dump
-        source: https://github.com/canonical/temporal-rocks.git
+        source: https://github.com/canonical/temporal-rocks
         source-type: git
         organize:
             LICENSE: licenses/LICENSE-temporal-server-rock
@@ -63,7 +63,7 @@ parts:
             - licenses/LICENSE-temporal
     temporal-cli-license:
         plugin: dump
-        source: https://github.com/temporalio/cli.git
+        source: https://github.com/temporalio/cli
         source-type: git
         source-tag: v1.3.0
         organize:

--- a/temporal-server/justfile
+++ b/temporal-server/justfile
@@ -19,7 +19,7 @@ clone-temporal-repo rock_version:
 	git clone --branch "v${rock_version}" --single-branch https://github.com/temporalio/temporal temporal
 
 # Pack the rock for the provided version
-pack version:
+pack version debug="":
 	just --justfile=../justfile pack temporal-server/${version} ${debug}
 
 # Clean the rockcraft project of the component and remove any existing rock files

--- a/temporal-server/justfile
+++ b/temporal-server/justfile
@@ -20,7 +20,7 @@ clone-temporal-repo rock_version:
 
 # Pack the rock for the provided version
 pack version:
-	just --justfile=../justfile pack temporal-server/${version}
+	just --justfile=../justfile pack temporal-server/${version} ${debug}
 
 # Clean the rockcraft project of the component and remove any existing rock files
 clean version:

--- a/temporal-server/justfile
+++ b/temporal-server/justfile
@@ -35,6 +35,8 @@ run version: (start-local-registry) (pack version) (push-to-local-registry versi
 
 	trap 'just stop-local-registry' EXIT
 
+	rock_version="$(just format_directory $version)"
+
 	rock_version="${version#temporal-server/}"
 
 	just clone-temporal-repo $rock_version
@@ -52,6 +54,8 @@ test version: (start-local-registry) (pack version) (push-to-local-registry vers
 	set -euxo pipefail
 
 	trap 'just stop-local-registry' EXIT
+
+	rock_version="$(just format_directory $version)"
 
 	rock_version="${version#temporal-server/}"
 


### PR DESCRIPTION
## Description
This PR introduces a rock for temporal admin tools (to be used in the `temporal-admin-k8s` charm). The rock contains all the necessary artifacts necessary to administer a temporal server deployment, including:
- temporal cli (replacing tctl)
- temporal-sql-tool (assuming that the temporal-server will be using a SQL backend, thus not including temporal-cassandra-tool in the rock)
- tdbg
- all the associated licenses (for all artifacts + the rock)

## Testing instructions
1. cd temporal-admin-tools
2. just test 1.23.1
(or) `just run 1.23.1` to get a shell in a pod container based on the rock

## Notes for Reviewers
The PR is opened against `main` to ensure that we get to run the goss tests (since PR test are only run on merge requests against `main`). However, the diff will contain changes in https://github.com/canonical/temporal-rocks/pull/2 until it is merged. Please disregard the `temporal-server` changes, and only focus on the `temporal-admin-tools/` directory for the meantime.

## Checklist (all that apply)
- [ ] Unit tests added or updated
- [x] Integration tests added or updated
- [ ] Documentation updated
