### PR TITLE
[WF-54] Ensure temporal cli presents correct output for --version

### DIFF
--- a/temporal-server/1.23.1/rockcraft.yaml
+++ b/temporal-server/1.23.1/rockcraft.yaml
@@ -44,6 +44,8 @@ parts:
         source-tag: v1.3.0
         build-snaps:
             - go/1.24/stable
+        override-build: |
+            go build -ldflags "-X 'github.com/temporalio/cli/temporalcli.Version=1.3.0'" -o ${CRAFT_PART_INSTALL}/bin/temporal ./cmd/temporal
     temporal-server-rock-license:
         plugin: dump
         source: https://github.com/canonical/temporal-rocks.git

--- a/temporal-server/goss.yaml
+++ b/temporal-server/goss.yaml
@@ -46,3 +46,19 @@ command:
     stderr: []
     timeout: 1000
     skip: false
+  'temporal --version':
+    exit-status: 0
+    exec: 'temporal --version'
+    stdout:
+    - temporal version 1.3.0 (Server 1.27.1, UI 2.36.0)
+    stderr: []
+    timeout: 1000
+    skip: false
+  'temporal-server --version':
+    exit-status: 0
+    exec: 'temporal-server --version'
+    stdout:
+    - temporal version 1.23.1
+    stderr: []
+    timeout: 1000
+    skip: false


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Temporal cli being built for the temporal-server rock presents an incorrect version when running `temporal --version`:

```
root@kgoss-tester-32257:/tmp/goss# temporal --version 
temporal version 0.0.0-DEV (Server 1.27.1, UI 2.36.0)
```

This PR uses `go build -ldflags` to patch the variable from which this version is printed by the client to ensure correct version presentation:

```
$ temporal --version
temporal version v1.26.2 (Server 1.27.1, UI 2.36.0)
```

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->
`just run temporal-server/1.23.1`
`$ temporal --version`

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [x] Integration tests added or updated
- [ ] Documentation updated

