### PR TITLE
feat(temporal-server): add 1.31.1 version of the rock

### DIFF
--- a/temporal-server/1.23.1/goss.yaml
+++ b/temporal-server/1.23.1/goss.yaml
@@ -37,3 +37,11 @@ command:
     stderr: []
     timeout: 1000
     skip: false
+  'temporal-sql-tool --version':
+    exit-status: 0
+    exec: 'temporal-sql-tool --version'
+    stdout:
+    - 'temporal-sql-tool version 0.0.1'
+    stderr: []
+    timeout: 1000
+    skip: false

--- a/temporal-server/1.23.1/goss.yaml
+++ b/temporal-server/1.23.1/goss.yaml
@@ -1,0 +1,39 @@
+gossfile:
+  goss_common.yaml: {}
+
+command:
+  'temporal --version':
+    exit-status: 0
+    exec: 'temporal --version'
+    stdout:
+    - 'temporal version 1.3.0 (Server 1.27.1, UI 2.36.0)'
+    stderr: []
+    timeout: 1000
+    skip: false
+  'temporal server start-dev':
+    exit-status: 0
+    exec: 'pebble stop temporal-server; timeout 5 temporal server start-dev; echo "exit code: $?"; pebble start temporal-server'
+    stdout:
+    - 'CLI 1.3.0 (Server 1.27.1, UI 2.36.0)'
+    - 'Server:  localhost:7233'
+    - 'UI:      http://localhost:8233'
+    - 'Stopping server...'
+    - 'exit code: 124'
+    stderr: []
+    skip: false
+  'temporal-server --version':
+    exit-status: 0
+    exec: 'temporal-server --version'
+    stdout:
+    - 'temporal version 1.23.1'
+    stderr: []
+    timeout: 1000
+    skip: false
+  'tdbg --version':
+    exit-status: 0
+    exec: 'tdbg --version'
+    stdout:
+    - 'tdbg version 1.23.1'
+    stderr: []
+    timeout: 1000
+    skip: false

--- a/temporal-server/1.31.1/goss.yaml
+++ b/temporal-server/1.31.1/goss.yaml
@@ -17,7 +17,7 @@ command:
     - 'Temporal CLI 1.7.2 (Server 1.31.1, UI 2.49.1)'
     - 'Temporal Server:  localhost:7233'
     - 'Temporal UI:      http://localhost:8233'
-    - 'exit code: 0'
+    - 'exit code: 124'
     stderr: []
     skip: false
   'temporal-server --version':

--- a/temporal-server/1.31.1/goss.yaml
+++ b/temporal-server/1.31.1/goss.yaml
@@ -14,11 +14,10 @@ command:
     exit-status: 0
     exec: 'pebble stop temporal-server; timeout 5 temporal server start-dev; echo "exit code: $?"; pebble start temporal-server'
     stdout:
-    - 'CLI 1.7.2 (Server 1.31.1, UI 2.49.1)'
-    - 'Server:  localhost:7233'
-    - 'UI:      http://localhost:8233'
-    - 'Stopping server...'
-    - 'exit code: 124'
+    - 'Temporal CLI 1.7.2 (Server 1.31.1, UI 2.49.1)'
+    - 'Temporal Server:  localhost:7233'
+    - 'Temporal UI:      http://localhost:8233'
+    - 'exit code: 0'
     stderr: []
     skip: false
   'temporal-server --version':
@@ -34,6 +33,14 @@ command:
     exec: 'tdbg --version'
     stdout:
     - 'tdbg version 1.31.1'
+    stderr: []
+    timeout: 1000
+    skip: false
+  'temporal-sql-tool --version':
+    exit-status: 0
+    exec: 'temporal-sql-tool --version'
+    stdout:
+    - 'temporal-sql-tool version 1.31.1'
     stderr: []
     timeout: 1000
     skip: false

--- a/temporal-server/1.31.1/goss.yaml
+++ b/temporal-server/1.31.1/goss.yaml
@@ -6,7 +6,7 @@ command:
     exit-status: 0
     exec: 'temporal --version'
     stdout:
-    - 'temporal version 0.0.0-DEV (Server 1.31.1, UI 2.49.1)'
+    - 'temporal version 1.7.2 (Server 1.31.1, UI 2.49.1)'
     stderr: []
     timeout: 1000
     skip: false
@@ -14,7 +14,7 @@ command:
     exit-status: 0
     exec: 'pebble stop temporal-server; timeout 5 temporal server start-dev; echo "exit code: $?"; pebble start temporal-server'
     stdout:
-    - 'CLI 0.0.0-DEV (Server 1.31.1, UI 2.49.1)'
+    - 'CLI 1.7.2 (Server 1.31.1, UI 2.49.1)'
     - 'Server:  localhost:7233'
     - 'UI:      http://localhost:8233'
     - 'Stopping server...'

--- a/temporal-server/1.31.1/goss.yaml
+++ b/temporal-server/1.31.1/goss.yaml
@@ -1,0 +1,39 @@
+gossfile:
+  goss_common.yaml: {}
+
+command:
+  'temporal --version':
+    exit-status: 0
+    exec: 'temporal --version'
+    stdout:
+    - 'temporal version 0.0.0-DEV (Server 1.31.1, UI 2.49.1)'
+    stderr: []
+    timeout: 1000
+    skip: false
+  'temporal server start-dev':
+    exit-status: 0
+    exec: 'pebble stop temporal-server; timeout 5 temporal server start-dev; echo "exit code: $?"; pebble start temporal-server'
+    stdout:
+    - 'CLI 0.0.0-DEV (Server 1.31.1, UI 2.49.1)'
+    - 'Server:  localhost:7233'
+    - 'UI:      http://localhost:8233'
+    - 'Stopping server...'
+    - 'exit code: 124'
+    stderr: []
+    skip: false
+  'temporal-server --version':
+    exit-status: 0
+    exec: 'temporal-server --version'
+    stdout:
+    - 'temporal version 1.31.1'
+    stderr: []
+    timeout: 1000
+    skip: false
+  'tdbg --version':
+    exit-status: 0
+    exec: 'tdbg --version'
+    stdout:
+    - 'tdbg version 1.31.1'
+    stderr: []
+    timeout: 1000
+    skip: false

--- a/temporal-server/1.31.1/rockcraft.yaml
+++ b/temporal-server/1.31.1/rockcraft.yaml
@@ -45,7 +45,7 @@ parts:
         build-snaps:
             - go/1.26/stable
         override-build: |
-            go build -ldflags "-X 'github.com/temporalio/cli/temporalcli.Version=1.3.0'" -o ${CRAFT_PART_INSTALL}/bin/temporal ./cmd/temporal
+            go build -ldflags "-X 'github.com/temporalio/cli/internal/temporalcli.Version=1.7.2'" -o ${CRAFT_PART_INSTALL}/bin/temporal ./cmd/temporal
     temporal-sql-tool:
         plugin: go
         source: https://github.com/temporalio/temporal

--- a/temporal-server/1.31.1/rockcraft.yaml
+++ b/temporal-server/1.31.1/rockcraft.yaml
@@ -1,0 +1,100 @@
+name: temporal-server
+# see https://documentation.ubuntu.com/rockcraft/en/1.11.0/explanation/bases/
+# for more information about bases and using 'bare' bases for chiselled rocks
+base: ubuntu@26.04 # the base environment for this rock
+version: '1.31.1' # just for humans. Semantic versioning is recommended
+summary: Rock for Temporal Server # 79 char long summary
+description: |
+    Temporal is a durable execution platform that enables developers to build scalable applications without sacrificing productivity or reliability. The Temporal server executes units of application logic called Workflows in a resilient manner that automatically handles intermittent failures, and retries failed operations.
+
+platforms: # the platforms this rock should be built on and run on
+    amd64:
+
+services:
+    temporal-server:
+        description: Service for temporal server
+        command: /usr/bin/temporal-server start
+        working-dir: /etc/temporal
+        override: replace
+        startup: enabled
+        user: ubuntu
+
+checks:
+    temporal-server-running:
+        override: replace
+        exec:
+            command: pgrep temporal-server
+
+
+parts:
+    temporal:
+        plugin: go
+        source: https://github.com/temporalio/temporal
+        source-subdir: cmd/server 
+        source-type: git
+        source-tag: v1.31.1
+        build-snaps:
+            - go/1.26/stable
+        organize:
+            bin/server: bin/temporal-server
+    temporal-cli:
+        plugin: go
+        source: https://github.com/temporalio/cli
+        source-type: git
+        source-tag: v1.7.2
+        build-snaps:
+            - go/1.26/stable
+        override-build: |
+            go build -ldflags "-X 'github.com/temporalio/cli/temporalcli.Version=1.3.0'" -o ${CRAFT_PART_INSTALL}/bin/temporal ./cmd/temporal
+    temporal-sql-tool:
+        plugin: go
+        source: https://github.com/temporalio/temporal
+        source-subdir: cmd/tools/sql
+        source-type: git
+        source-tag: v1.31.1
+        build-snaps:
+            - go/1.26/stable
+        organize:
+            bin/sql: bin/temporal-sql-tool
+    tdbg:
+        plugin: go
+        source: https://github.com/temporalio/temporal
+        source-subdir: cmd/tools/tdbg
+        source-type: git
+        source-tag: v1.31.1
+        build-snaps:
+            - go/1.26/stable
+    temporal-server-rock-license:
+        plugin: dump
+        source: https://github.com/canonical/temporal-rocks
+        source-type: git
+        organize:
+            LICENSE: licenses/LICENSE-temporal-server-rock
+        stage:
+            - licenses/LICENSE-temporal-server-rock
+    temporal-license-and-schema:
+        plugin: dump
+        source: https://github.com/temporalio/temporal
+        source-type: git
+        source-tag: v1.31.1
+        organize:
+            schema: etc/temporal/schema
+            LICENSE: licenses/LICENSE-temporal
+        stage:
+            - etc/temporal/schema
+            - licenses/LICENSE-temporal
+    temporal-cli-license:
+        plugin: dump
+        source: https://github.com/temporalio/cli
+        source-type: git
+        source-tag: v1.7.2
+        organize:
+            LICENSE: licenses/LICENSE-temporal-cli
+        stage:
+            - licenses/LICENSE-temporal-cli
+    prerequisite-directories:
+        plugin: nil
+        source: .
+        source-type: local
+        override-build: |
+            mkdir -p ${CRAFT_PART_INSTALL}/etc/temporal

--- a/temporal-server/goss_common.yaml
+++ b/temporal-server/goss_common.yaml
@@ -74,46 +74,11 @@ command:
     - 'SERVING'
     stderr: []
     skip: false
-  'temporal --version':
-    exit-status: 0
-    exec: 'temporal --version'
-    stdout:
-    - 'temporal version 1.3.0 (Server 1.27.1, UI 2.36.0)'
-    stderr: []
-    timeout: 1000
-    skip: false
-  'temporal-server --version':
-    exit-status: 0
-    exec: 'temporal-server --version'
-    stdout:
-    - 'temporal version 1.23.1'
-    stderr: []
-    timeout: 1000
-    skip: false
-  'temporal server start-dev':
-    exit-status: 0
-    exec: 'pebble stop temporal-server; timeout 5 temporal server start-dev; echo "exit code: $?"; pebble start temporal-server'
-    stdout:
-    - 'CLI 1.3.0 (Server 1.27.1, UI 2.36.0)'
-    - 'Server:  localhost:7233'
-    - 'UI:      http://localhost:8233'
-    - 'Stopping server...'
-    - 'exit code: 124'
-    stderr: []
-    skip: false
   'temporal-sql-tool --version':
     exit-status: 0
     exec: 'temporal-sql-tool --version'
     stdout:
     - 'temporal-sql-tool version 0.0.1'
-    stderr: []
-    timeout: 1000
-    skip: false
-  'tdbg --version':
-    exit-status: 0
-    exec: 'tdbg --version'
-    stdout:
-    - 'tdbg version 1.23.1'
     stderr: []
     timeout: 1000
     skip: false

--- a/temporal-server/goss_common.yaml
+++ b/temporal-server/goss_common.yaml
@@ -74,11 +74,3 @@ command:
     - 'SERVING'
     stderr: []
     skip: false
-  'temporal-sql-tool --version':
-    exit-status: 0
-    exec: 'temporal-sql-tool --version'
-    stdout:
-    - 'temporal-sql-tool version 0.0.1'
-    stderr: []
-    timeout: 1000
-    skip: false

--- a/temporal-server/justfile
+++ b/temporal-server/justfile
@@ -41,9 +41,9 @@ run version: (start-local-registry) (pack version) (push-to-local-registry versi
 
 	just clone-temporal-repo $rock_version
 
-	extra_options="-d temporal/config/ -e TEMPORAL_ROOT=/etc/temporal -e TEMPORAL_ENVIRONMENT=development-sqlite"
+	extra_options="-d temporal/config/ -d ${rock_version}/goss.yaml -d goss_common.yaml -e TEMPORAL_ROOT=/etc/temporal -e TEMPORAL_ENVIRONMENT=development-sqlite"
 	goss_vars="GOSS_KUBECTL_BIN=\"$(which kubectl)\" GOSS_OPTS=\"--retry-timeout 60s --color\" GOSS_CONTAINER_PATH=\"/etc/temporal\""
-	
+
 	eval "env ${goss_vars} kgoss edit -i localhost:5000/temporal-server-dev:${rock_version} ${extra_options}"
 
 	rm -rf temporal
@@ -61,9 +61,9 @@ test version: (start-local-registry) (pack version) (push-to-local-registry vers
 
 	just clone-temporal-repo $rock_version
 
-	extra_options+="-d temporal/config/ -e TEMPORAL_ROOT=/etc/temporal -e TEMPORAL_ENVIRONMENT=development-sqlite"
+	extra_options="-d temporal/config/ -d ${rock_version}/goss.yaml -d goss_common.yaml -e TEMPORAL_ROOT=/etc/temporal -e TEMPORAL_ENVIRONMENT=development-sqlite"
 	goss_vars="GOSS_KUBECTL_BIN=\"$(which kubectl)\" GOSS_OPTS=\"--retry-timeout 60s\" GOSS_CONTAINER_PATH=\"/etc/temporal\""
-	
+
 	eval "env ${goss_vars} kgoss run -i localhost:5000/temporal-server-dev:${rock_version} ${extra_options}"
 
 	rm -rf temporal


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

This commit adds 1.31.1/rockcraft.yaml and refactors the testing framework to make it more scalable for adding more versions in the future.

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

1. Build the rock and run a container
```
rockcraft pack -v
rockcraft.skopeo --insecure-policy copy oci-archive:temporal-server_1.31.1_amd64.rock docker-daemon:temporal:1.31
docker run -ti --rm --entrypoint /bin/bash temporal:1.31
```
2. Check for the various binaries and check their versions

```
# temporal-server --version
temporal version 1.31.1

# temporal-sql-tool --version
temporal-sql-tool version 1.31.1

# tdbg --version
tdbg version 1.31.1

temporal --version
temporal version 0.0.0-DEV (Server 1.31.1, UI 2.49.1)
```

3. Optionally, start a server using the CLI

```
# temporal server start-dev
Temporal CLI 0.0.0-DEV (Server 1.31.1, UI 2.49.1)

Temporal Server:  localhost:7233
Temporal UI:      http://localhost:8233
Temporal Metrics: http://localhost:33409/metrics
```

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [x] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated

