### PR TITLE
feat(temporal-ui): add 2.52.1 version of the rock

### DIFF
--- a/temporal-ui/2.39.0/goss.yaml
+++ b/temporal-ui/2.39.0/goss.yaml
@@ -1,0 +1,12 @@
+gossfile:
+  goss_common.yaml: {}
+
+command:
+  'ui-server --version':
+    exit-status: 0
+    exec: 'ui-server --version'
+    stdout:
+    - 'Temporal UI version 2.39.0'
+    stderr: []
+    timeout: 1000
+    skip: false

--- a/temporal-ui/2.52.1/goss.yaml
+++ b/temporal-ui/2.52.1/goss.yaml
@@ -1,0 +1,12 @@
+gossfile:
+  goss_common.yaml: {}
+
+command:
+  'ui-server --version':
+    exit-status: 0
+    exec: 'ui-server --version'
+    stdout:
+    - 'Temporal UI version 2.52.1'
+    stderr: []
+    timeout: 1000
+    skip: false

--- a/temporal-ui/2.52.1/rockcraft.yaml
+++ b/temporal-ui/2.52.1/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: temporal-ui
 # see https://documentation.ubuntu.com/rockcraft/en/1.12.0/explanation/bases/
 # for more information about bases and using 'bare' bases for chiselled rocks
-base: ubuntu@24.04 # the base environment for this rock
+base: ubuntu@26.04 # the base environment for this rock
 version: '2.52.1' # just for humans. Semantic versioning is recommended
 summary: Rock for Temporal UI # 79 char long summary
 description: |

--- a/temporal-ui/2.52.1/rockcraft.yaml
+++ b/temporal-ui/2.52.1/rockcraft.yaml
@@ -31,7 +31,7 @@ parts:
         source-type: git
         source-tag: v2.52.1
         build-snaps:
-            - go/1.24/stable
+            - go/1.26/stable
             - node/22/stable
         override-build: |
             set -euxo pipefail

--- a/temporal-ui/2.52.1/rockcraft.yaml
+++ b/temporal-ui/2.52.1/rockcraft.yaml
@@ -1,0 +1,68 @@
+name: temporal-ui
+# see https://documentation.ubuntu.com/rockcraft/en/1.12.0/explanation/bases/
+# for more information about bases and using 'bare' bases for chiselled rocks
+base: ubuntu@24.04 # the base environment for this rock
+version: '2.52.1' # just for humans. Semantic versioning is recommended
+summary: Rock for Temporal UI # 79 char long summary
+description: |
+    The Temporal UI provides a browser-based user interface for Temporal, allowing users to view Workflow Execution state, metadata, and debug their Temporal applications.
+platforms: # the platforms this rock should be built on and run on
+    amd64:
+
+services:
+    temporal-ui:
+        description: UI for Temporal
+        command: /usr/bin/ui-server start
+        working-dir: /home/ui-server
+        override: replace
+        startup: enabled
+        user: ubuntu
+
+checks:
+    temporal-ui-running:
+        override: replace
+        exec:
+            command: pgrep ui-server
+
+parts:
+    temporal-ui-server:
+        plugin: go
+        source: https://github.com/temporalio/ui
+        source-type: git
+        source-tag: v2.52.1
+        build-snaps:
+            - go/1.24/stable
+            - node/22/stable
+        override-build: |
+            set -euxo pipefail
+
+            npm install --global corepack@latest
+            corepack enable pnpm
+
+            pnpm install < <(yes | head -n 1)
+            pnpm build:server
+
+            cd server
+            go build -o ${CRAFT_PART_INSTALL}/bin/ui-server ./cmd/server/main.go
+    temporal-ui-rocks-license:
+        plugin: dump
+        source: https://github.com/canonical/temporal-rocks
+        source-type: git
+        organize:
+            LICENSE: licenses/LICENSE-temporal-ui-rock
+        stage:
+            - licenses/LICENSE-temporal-ui-rock
+    temporal-ui-license:
+        plugin: dump
+        source: https://github.com/temporalio/ui
+        source-type: git
+        organize:
+            LICENSE: licenses/LICENSE-temporal-ui
+        stage:
+            - licenses/LICENSE-temporal-ui
+    prerequisite-directories:
+        plugin: nil
+        source: .
+        source-type: local
+        override-build: |
+            mkdir -p ${CRAFT_PART_INSTALL}/home/ui-server

--- a/temporal-ui/goss_common.yaml
+++ b/temporal-ui/goss_common.yaml
@@ -31,15 +31,6 @@ group:
 process:
   ui-server:
     running: true
-command:
-  'ui-server --version':
-    exit-status: 0
-    exec: 'ui-server --version'
-    stdout:
-    - 'Temporal UI version 2.39.0'
-    stderr: []
-    timeout: 1000
-    skip: false
 http:
   http://localhost:8081:
     status: 200

--- a/temporal-ui/justfile
+++ b/temporal-ui/justfile
@@ -41,9 +41,9 @@ run version: (start-local-registry) (pack version) (push-to-local-registry versi
 
 	just clone-ui-repo $rock_version
 
-	extra_options="-d ui/server/config -e TEMPORAL_ROOT=/home/ui-server -e TEMPORAL_ENVIRONMENT=development"
+	extra_options="-d ui/server/config -d ${rock_version}/goss.yaml -d goss_common.yaml -e TEMPORAL_ROOT=/home/ui-server -e TEMPORAL_ENVIRONMENT=development"
 	goss_vars="GOSS_KUBECTL_BIN=\"$(which kubectl)\" GOSS_OPTS=\"--retry-timeout 60s --color\" GOSS_CONTAINER_PATH=\"/home/ui-server\""
-	
+
 	eval "env ${goss_vars} kgoss edit -i localhost:5000/temporal-ui-dev:${rock_version} ${extra_options}"
 
 	rm -rf ui
@@ -60,9 +60,9 @@ test version: (start-local-registry) (pack version) (push-to-local-registry vers
 
 	just clone-ui-repo $rock_version
 
-	extra_options="-d ui/server/config -e TEMPORAL_ROOT=/home/ui-server -e TEMPORAL_ENVIRONMENT=development"
+	extra_options="-d ui/server/config -d ${rock_version}/goss.yaml -d goss_common.yaml -e TEMPORAL_ROOT=/home/ui-server -e TEMPORAL_ENVIRONMENT=development"
 	goss_vars="GOSS_KUBECTL_BIN=\"$(which kubectl)\" GOSS_OPTS=\"--retry-timeout 60s\" GOSS_CONTAINER_PATH=\"/home/ui-server\""
-	
+
 	eval "env ${goss_vars} kgoss run -i localhost:5000/temporal-ui-dev:${rock_version} ${extra_options}"
 
 	rm -rf ui


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->


This commit adds 2.52.1/rockcraft.yaml and refactors the testing framework to make it more scalable for adding more versions in the future.

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

1. Build the rock and run a container
```
rockcraft pack -v
rockcraft.skopeo --insecure-policy copy oci-archive:temporal-ui*.rock docker-daemon:temporal-ui:0.1
docker run -ti --rm --entrypoint /bin/bash temporal-ui:0.1
```
2. Check for the various binaries and check their versions

```
# ui-server --version
Temporal UI version 2.52.1
```

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [x] Unit tests added or updated
- [x] Integration tests added or updated
- [ ] Documentation updated

